### PR TITLE
Potential fix for code scanning alert no. 54: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cors": "^2.8.5",
     "bcryptjs": "^2.4.3",
     "@simplewebauthn/server": "^8.6.0",
-    "base64url": "^3.0.1"
+    "base64url": "^3.0.1",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const crypto = require('crypto');
 const cors = require('cors');
 const bcrypt = require('bcryptjs');
+const RateLimit = require('express-rate-limit');
 const app = express();
 
 app.use(cors());
@@ -148,7 +149,12 @@ app.post('/api/passkey/auth/options', (req, res) => {
   res.json(options);
 });
 
-app.post('/api/passkey/auth/verify', async (req, res) => {
+const authVerifyLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+app.post('/api/passkey/auth/verify', authVerifyLimiter, async (req, res) => {
   const { name, assertionResponse } = req.body;
   const user = users.find(u => u.name === name && u.passkeys && u.passkeys.length > 0);
   const challengeData = passkeyChallenge[getSessionId(req)];


### PR DESCRIPTION
Potential fix for [https://github.com/blake437/Blog/security/code-scanning/54](https://github.com/blake437/Blog/security/code-scanning/54)

To address the issue, we will implement rate limiting for the `/api/passkey/auth/verify` endpoint using the `express-rate-limit` package. This package allows us to define a maximum number of requests per time window for specific routes. We will configure a rate limiter with reasonable limits (e.g., 100 requests per 15 minutes) and apply it to the affected route.

Steps to fix:
1. Install the `express-rate-limit` package.
2. Import the package in `server.js`.
3. Define a rate limiter with appropriate settings.
4. Apply the rate limiter middleware to the `/api/passkey/auth/verify` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
