### PR TITLE
Potential fix for code scanning alert no. 41: Missing rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -101,7 +101,12 @@ app.post('/api/passkey/register/options', requireAuth, (req, res) => {
 });
 
 // Finish passkey registration
-app.post('/api/passkey/register/verify', requireAuth, async (req, res) => {
+const registerVerifyLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+app.post('/api/passkey/register/verify', registerVerifyLimiter, requireAuth, async (req, res) => {
   const { attestationResponse, nickname } = req.body;
   const regData = passkeyChallenge[getSessionId(req)];
   if (!regData) return res.status(400).json({ error: "No registration in progress" });


### PR DESCRIPTION
Potential fix for [https://github.com/blake437/Blog/security/code-scanning/41](https://github.com/blake437/Blog/security/code-scanning/41)

To address the issue, we will add rate-limiting middleware to the `/api/passkey/register/verify` route. This will ensure that requests to this route are limited to a reasonable number within a specified time window, preventing abuse.

**Steps to fix:**
1. Define a rate limiter using the `express-rate-limit` package, similar to the existing `authOptionsLimiter` and `authVerifyLimiter`.
2. Apply the rate limiter to the `/api/passkey/register/verify` route by passing it as middleware.

**Required changes:**
- Add a new rate limiter definition for the `/api/passkey/register/verify` route.
- Update the route handler to include the rate limiter middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
